### PR TITLE
Adjustments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 ffmpeg2pass-0.log
 __pycache__
+buttonDetails.py
+char.py
+ocr.py
+colors.py
+inputs.json

--- a/encode.py
+++ b/encode.py
@@ -8,6 +8,9 @@ import os
 import shutil
 import sys
 import png
+import ocr
+
+startTime = time.time()
 
 with open("settings.yaml", 'r') as stream:
   settings = yaml.safe_load(stream)
@@ -18,7 +21,8 @@ try:
   print('creating output folder '+settings['NewOutputFolder'])
   os.mkdir(targetDir)
 except FileExistsError:
-  print("Output folder \""+ settings['NewOutputFolder'] +"\" already exists. Please rename output directory to avoid losing work.")
+  # TODO: add a sequential digit to the output folder instead of quitting.
+  print("Output folder \""+ settings['NewOutputFolder'] +"\" already exists.\nPlease rename output directory to avoid losing work.")
   sys.exit("Exiting")
 
 # shutil.copyfile(os.path.dirname(os.path.realpath('settings.yaml')),settings['OutFileDir']+settings['NewOutputFolder']+"py_vp9.yaml")
@@ -44,12 +48,16 @@ if settings['CreateImages']:
     print('Saved images.')
   if png.createMontages(settings):
     print('saved montages.')
+  if settings['RunOCR']:
+    # Run adjacent ocr script to remove duplicate frames
+    os.mkdir(settings['OutFileDir']+settings['NewOutputFolder']+'/unique')
+    if ocr.readFolderInputs(settings['OutFileDir']+settings['NewOutputFolder']+'/images/*', settings['OutFileDir']+settings['NewOutputFolder']+'/unique/'):
+      print('saved unique files.')  
 
 if settings['Debug']:
   pp = pprint.PrettyPrinter(indent=2)
   print()
   pp.pprint(settings)
-
 
 result = False
 filesEncoded = 0
@@ -106,6 +114,8 @@ if result == True:
   print('\n\nEncoded '+str(filesEncoded)+' files. Skipped '+str(filesSkipped)+'.'+' Press Enter to continue...')
 else:
   print('\n\nThere was an issue with encoding. Press Enter to continue...')
+
+print("--- %s seconds ---" % (time.time() - startTime))
 
 # wait for user input. this makes it so the output doesn't
 # dissapear immediately when invoking outside the CLI.

--- a/png.py
+++ b/png.py
@@ -35,7 +35,7 @@ def createPngs(settings):
   command.append('scale=320x240')
   command.append('-sws_flags')
   command.append('neighbor')
-  command.append(settings['OutFileDir']+settings['NewOutputFolder']+'/images/'+'zgv%04d.png')
+  command.append(settings['OutFileDir']+settings['NewOutputFolder']+'/images/'+'zgv%05d.png')
 
   for arg in command:
     # Print the args without the brackets and commas
@@ -116,8 +116,8 @@ def createMontage(settings,imageOffset,gridWidth):
 
 def createMontages(settings):
 
-  imageOffsets = [4,12,108]
-  gridWidths = [2,4,12]
+  imageOffsets = [4,12,108,432]
+  gridWidths = [2,4,12,24]
 
   for i in range(len(imageOffsets)):
     createMontage(settings,imageOffsets[i],gridWidths[i])

--- a/png.py
+++ b/png.py
@@ -121,3 +121,24 @@ def createMontages(settings):
 
   for i in range(len(imageOffsets)):
     createMontage(settings,imageOffsets[i],gridWidths[i])
+    createJPG(settings,imageOffsets[i],gridWidths[i])
+
+def createJPG(settings,imageOffset,gridWidth):
+  # ad-hoc: take the montage png that was just saved and make it a jpg
+  print('createJPG')
+  command = ['magick']
+
+  command.append(settings['OutFileDir']+settings['NewOutputFolder']+'/montage'+str(gridWidth)+'.png')
+  command.append("-quality")
+  command.append("95")
+  command.append(settings['OutFileDir']+settings['NewOutputFolder']+'/montage'+str(gridWidth)+'.jpg')
+
+  t1 = time.localtime()
+  print("\nExporting JPGs...: "+ time.strftime("%H:%M:%S", t1))
+
+  print(command)
+
+  commandResult = subprocess.run(command, capture_output=True)
+  print(commandResult)
+
+  return True

--- a/settings.yaml
+++ b/settings.yaml
@@ -7,7 +7,7 @@ InputExtension: '.avi'
 
 # OutFileDir: C:/video/py_vp9/
 OutFileDir: /home/ec2-user/video/input/
-NewOutputFolder: 'kz-ambience3'
+NewOutputFolder: 'kz-ambience4'
 OutputExtension: '.webm'
 # OutputCodec: 'libvpx'
 OutputCodec: 'libvpx-vp9'

--- a/settings.yaml
+++ b/settings.yaml
@@ -1,19 +1,20 @@
 ---
-InputFileDir: C:/video/lossless/
-# InputFileDir: C:/video/releaseOBS/
-InputFilename: 2022-04-22_21-04-08
+# InputFileDir: C:/video/lossless/
+InputFileDir: /var/py_vp9/input
+InputFilename: 2022-08-26_17-16-46
 # InputExtension: '.mp4'
 InputExtension: '.avi'
 
-OutFileDir: C:/video/py_vp9/
-NewOutputFolder: 'blockpuzzle-add264'
+# OutFileDir: C:/video/py_vp9/
+OutFileDir: /var/py_vp9/output
+NewOutputFolder: 'kz-ambience'
 OutputExtension: '.webm'
 # OutputCodec: 'libvpx'
 OutputCodec: 'libvpx-vp9'
 
 StripAudio: false
 TrimVideo: true
-TrimStart: '00:00:00.150'
+TrimStart: '00:00:00.000'
 TrimVideoEnd: false
 TrimEnd: '00:00:00.000'
 
@@ -22,8 +23,8 @@ ScaleMode: neighbor
 OutResolution: 320x240
 # OutResolution: 640x480
 
-PixelFormat: yuv444p
 SetPixelFormat: true
+PixelFormat: yuv444p
 PixelFormats:
   - 'yuv444p'
   - 'yuv420p'
@@ -43,7 +44,7 @@ CRF: #batch mode crf
   # - '0'
 
 BatchOutputResolutions:
-  - 'default'
+  # - 'default'
   - '320x240'
   # - '313x237'
 
@@ -52,8 +53,9 @@ BatchCodecs:
   - 'libx264'
   - 'libvpx-vp9'
 
-CreateImages: false
-
 Debug: true
 SkipEncoding: false
-SkipImages: true
+
+CreateImages: true
+#extra flag: generate commands but do not execute
+SkipImages: false

--- a/settings.yaml
+++ b/settings.yaml
@@ -7,7 +7,7 @@ InputExtension: '.avi'
 
 # OutFileDir: C:/video/py_vp9/
 OutFileDir: /home/ec2-user/video/input/
-NewOutputFolder: 'kz-ambience2'
+NewOutputFolder: 'kz-ambience3'
 OutputExtension: '.webm'
 # OutputCodec: 'libvpx'
 OutputCodec: 'libvpx-vp9'

--- a/settings.yaml
+++ b/settings.yaml
@@ -58,4 +58,4 @@ SkipEncoding: false
 
 CreateImages: true
 #extra flag: generate commands but do not execute
-SkipImages: false
+# SkipImages: false

--- a/settings.yaml
+++ b/settings.yaml
@@ -1,12 +1,12 @@
 ---
 # InputFileDir: C:/video/lossless/
-InputFileDir: /var/py_vp9/input
+InputFileDir: /home/ec2-user/video/input/
 InputFilename: 2022-08-26_17-16-46
 # InputExtension: '.mp4'
 InputExtension: '.avi'
 
 # OutFileDir: C:/video/py_vp9/
-OutFileDir: /var/py_vp9/output
+OutFileDir: /home/ec2-user/video/input/
 NewOutputFolder: 'kz-ambience'
 OutputExtension: '.webm'
 # OutputCodec: 'libvpx'
@@ -36,11 +36,11 @@ Deadline: 'best'
 Batch: true
 CRFDefault: '20'
 CRF: #batch mode crf
-  - '50'
-  - '40'
+  # - '50'
+  # - '40'
   - '30'
-  - '20'
-  - '10'
+  # - '20'
+  # - '10'
   # - '0'
 
 BatchOutputResolutions:

--- a/settings.yaml
+++ b/settings.yaml
@@ -7,7 +7,7 @@ InputExtension: '.avi'
 
 # OutFileDir: C:/video/py_vp9/
 OutFileDir: /home/ec2-user/video/input/
-NewOutputFolder: 'kz-ambience4'
+NewOutputFolder: 'kz-ambience5'
 OutputExtension: '.webm'
 # OutputCodec: 'libvpx'
 OutputCodec: 'libvpx-vp9'

--- a/settings.yaml
+++ b/settings.yaml
@@ -1,20 +1,21 @@
 ---
-# InputFileDir: C:/video/lossless/
-InputFileDir: /home/ec2-user/video/input/
-InputFilename: 2022-08-26_17-16-46
+InputFileDir: C:/video/lossless/
+# InputFileDir: /home/ec2-user/video/input/
+InputFilename: 2022-08-28_17-16-42
 # InputExtension: '.mp4'
 InputExtension: '.avi'
 
-# OutFileDir: C:/video/py_vp9/
-OutFileDir: /home/ec2-user/video/input/
-NewOutputFolder: 'kz-ambience5'
+OutFileDir: C:/video/py_vp9/
+# OutFileDir: /home/ec2-user/video/input/
+NewOutputFolder: 'gohma-2ko'
 OutputExtension: '.webm'
 # OutputCodec: 'libvpx'
 OutputCodec: 'libvpx-vp9'
 
 StripAudio: false
+
 TrimVideo: true
-TrimStart: '00:00:00.000'
+TrimStart: '00:00:00.182'
 TrimVideoEnd: false
 TrimEnd: '00:00:00.000'
 
@@ -36,26 +37,26 @@ Deadline: 'best'
 Batch: true
 CRFDefault: '20'
 CRF: #batch mode crf
-  # - '50'
-  # - '40'
+  - '50'
+  - '40'
   - '30'
-  # - '20'
-  # - '10'
-  # - '0'
+  - '20'
+  - '10'
+  - '0'
 
 BatchOutputResolutions:
   - 'default'
-  # - '320x240'
+  - '320x240'
   # - '313x237'
 
 BatchCodecs:
   # - 'libvpx'
   - 'libx264'
-  # - 'libvpx-vp9'
+  - 'libvpx-vp9'
 
 Debug: true
 SkipEncoding: false
 
-CreateImages: false
+CreateImages: true
 #extra flag: generate commands but do not execute
-SkipImages: true
+SkipImages: false

--- a/settings.yaml
+++ b/settings.yaml
@@ -44,14 +44,14 @@ CRF: #batch mode crf
   # - '0'
 
 BatchOutputResolutions:
-  # - 'default'
-  - '320x240'
+  - 'default'
+  # - '320x240'
   # - '313x237'
 
 BatchCodecs:
   # - 'libvpx'
   - 'libx264'
-  - 'libvpx-vp9'
+  # - 'libvpx-vp9'
 
 Debug: true
 SkipEncoding: false

--- a/settings.yaml
+++ b/settings.yaml
@@ -1,13 +1,14 @@
 ---
-InputFileDir: C:/video/lossless/
+# InputFileDir: E:/media/zgv/backups-april2022/
 # InputFileDir: /home/ec2-user/video/input/
-InputFilename: 2022-08-28_17-16-42
+InputFileDir: C:/video/lossless/
+InputFilename: 2022-10-18_22-51-24
 # InputExtension: '.mp4'
 InputExtension: '.avi'
 
 OutFileDir: C:/video/py_vp9/
 # OutFileDir: /home/ec2-user/video/input/
-NewOutputFolder: 'gohma-2ko'
+NewOutputFolder: 'output'
 OutputExtension: '.webm'
 # OutputCodec: 'libvpx'
 OutputCodec: 'libvpx-vp9'
@@ -15,7 +16,7 @@ OutputCodec: 'libvpx-vp9'
 StripAudio: false
 
 TrimVideo: true
-TrimStart: '00:00:00.182'
+TrimStart: '00:00:00.000'
 TrimVideoEnd: false
 TrimEnd: '00:00:00.000'
 
@@ -48,6 +49,7 @@ BatchOutputResolutions:
   - 'default'
   - '320x240'
   # - '313x237'
+  # - '2880x2160' # (4k)
 
 BatchCodecs:
   # - 'libvpx'
@@ -60,3 +62,5 @@ SkipEncoding: false
 CreateImages: true
 #extra flag: generate commands but do not execute
 SkipImages: false
+
+RunOCR: true

--- a/settings.yaml
+++ b/settings.yaml
@@ -56,6 +56,6 @@ BatchCodecs:
 Debug: true
 SkipEncoding: false
 
-CreateImages: true
+CreateImages: false
 #extra flag: generate commands but do not execute
 SkipImages: true

--- a/settings.yaml
+++ b/settings.yaml
@@ -7,7 +7,7 @@ InputExtension: '.avi'
 
 # OutFileDir: C:/video/py_vp9/
 OutFileDir: /home/ec2-user/video/input/
-NewOutputFolder: 'kz-ambience'
+NewOutputFolder: 'kz-ambience2'
 OutputExtension: '.webm'
 # OutputCodec: 'libvpx'
 OutputCodec: 'libvpx-vp9'
@@ -58,4 +58,4 @@ SkipEncoding: false
 
 CreateImages: true
 #extra flag: generate commands but do not execute
-# SkipImages: false
+SkipImages: true

--- a/vp9.py
+++ b/vp9.py
@@ -79,7 +79,7 @@ def encodeVP9(crf, settings):
 
   # TODO: add operating system check so this works on Linux.
   # firstPass.append("NUL")
-  firstPass.append("/dev/null")
+  firstPass.append("temp")
 
 
   if settings['TrimVideo']:

--- a/vp9.py
+++ b/vp9.py
@@ -78,7 +78,9 @@ def encodeVP9(crf, settings):
   firstPass.append("webm")
 
   # TODO: add operating system check so this works on Linux.
-  firstPass.append("NUL")
+  # firstPass.append("NUL")
+  firstPass.append("/dev/null")
+
 
   if settings['TrimVideo']:
     if settings['TrimStart']:

--- a/vp9.py
+++ b/vp9.py
@@ -16,11 +16,14 @@ def encodeVP9(crf, settings):
   secondPass = ['ffmpeg']
 
   # Used to denote scaled resolution in output file
-  horizontalLines = "480"
+  horizontalLines = "480" # default when not scaling
   if settings['Scale']:
     # These args will be omitted entirely if Scale is false.
-    # TODO: make the horizontallines logic more robust, it will fail on 4-digit resolutions.
-    horizontalLines = settings['OutResolution'][4:7]
+    resString = settings['OutResolution']
+    # Split the output resolution string to get the number after the x
+    # This works with all output resolutions
+    charX = resString.index('x')
+    horizontalLines = resString[charX+1:len(resString)]
 
   # Check if a CRF value was passed in - this will be used by batch mode.
   if crf == "defaultCRF":

--- a/vp9.py
+++ b/vp9.py
@@ -79,7 +79,8 @@ def encodeVP9(crf, settings):
 
   # TODO: add operating system check so this works on Linux.
   # firstPass.append("NUL")
-  firstPass.append("temp")
+  firstPass.append("temp/t")
+  # firstPass.append("temp")
 
 
   if settings['TrimVideo']:

--- a/vp9.py
+++ b/vp9.py
@@ -78,8 +78,8 @@ def encodeVP9(crf, settings):
   firstPass.append("webm")
 
   # TODO: add operating system check so this works on Linux.
-  # firstPass.append("NUL")
-  firstPass.append("temp/t")
+  firstPass.append("NUL")
+  # firstPass.append("temp/t")
   # firstPass.append("temp")
 
 

--- a/x264.py
+++ b/x264.py
@@ -29,7 +29,10 @@ def encodex264(crf, settings):
     crf = settings['CRFDefault']
   
   if crf == '10':
-    print('x264: Skipping crf 10 encode.. they\'re too big with libx264.')
+    print('x264: Skipping crf 10 encode..')
+    return 2
+  if crf == '0':
+    print('x264: Skipping crf 0 encode.')
     return 2
 
   # Build first pass


### PR DESCRIPTION
- Add ocr package and attempt to read frame numbers:
  - de-dupe the frame dump and output a subfolder of unique images
  - Read gz analog data (Not currently useful)
  - Add syncing data for FE frame number lookups (WIP)
- Add basic linux path support
- compress montage png files to jpg
- Fix support for 4-digit resolutions - Always get the correct horizontalLines substring of an ffmpeg-style output resolution, such as "640x480" or "2880x2160"
- Pad sequential image filenames with five 0s, for a max duration of 99,999 frames (~30,000 at 20hz), or 27 minutes. This is shorter than the gz limit of 65,535, but far longer than the use case will ever call for.